### PR TITLE
Updated nginx ingress controller arg

### DIFF
--- a/ephemeral-env/skaffold.template.yaml
+++ b/ephemeral-env/skaffold.template.yaml
@@ -75,7 +75,7 @@ profiles:
               - ../nginx-ingress-controller/custom-values.yaml
             setValues:
               controller.service.annotations.external-dns\.alpha\.kubernetes\.io/hostname: DOMAIN_TO_USE
-              controller.scope.namespace: ${ephemeral_dev_initials}-${ephemeral_work_item_id}
+              controller.watchNamespace: ${ephemeral_dev_initials}-${ephemeral_work_item_id}
               #Following annotation is to be used if TLS is to be enabled on the ingress
               #Requires certificate to be provisioned through ACM
               #nginx-ingress.controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-ssl-cert": ACM_CERT_ARN
@@ -110,7 +110,7 @@ profiles:
               - ../nginx-ingress-controller/custom-values.yaml
             setValues:
               controller.service.annotations.external-dns\.alpha\.kubernetes\.io/hostname: DOMAIN_TO_USE
-              controller.scope.namespace: ${ephemeral_dev_initials}-${ephemeral_work_item_id}
+              controller.watchNamespace: ${ephemeral_dev_initials}-${ephemeral_work_item_id}
               #Following annotation is to be used if TLS is to be enabled on the ingress
               #Requires certificate to be provisioned through ACM
               #nginx-ingress.controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-ssl-cert": ACM_CERT_ARN


### PR DESCRIPTION
Scope ingress controller to specific namespace. This allows multiple environments to be run without interfering.

This issue happened since the values file format for nginx-stable/nginx-ingress is different from the ingress we have been using earlier. For now, added the arg to skaffold file. Long term fix - need to evaluate the nginx-ingress-controller/custom-values.yaml file and correct the format.

This fixes #10 